### PR TITLE
Replace yield() with _yield() in Laravel.

### DIFF
--- a/app/laravel/blade.php
+++ b/app/laravel/blade.php
@@ -359,7 +359,7 @@ class Blade {
 	/**
 	 * Rewrites Blade @yield statements into Section statements.
 	 *
-	 * The Blade @yield statement is a shortcut to the Section::yield method.
+	 * The Blade @yield statement is a shortcut to the Section::_yield method.
 	 *
 	 * @param  string  $value
 	 * @return string
@@ -368,7 +368,7 @@ class Blade {
 	{
 		$pattern = static::matcher('yield');
 
-		return preg_replace($pattern, '$1<?php echo \\Laravel\\Section::yield$2; ?>', $value);
+		return preg_replace($pattern, '$1<?php echo \\Laravel\\Section::_yield$2; ?>', $value);
 	}
 
 	/**

--- a/app/laravel/documentation/views/templating.md
+++ b/app/laravel/documentation/views/templating.md
@@ -44,7 +44,7 @@ View sections provide a simple way to inject content into layouts from nested vi
 #### Rendering the contents of a section:
 
 	<head>
-		<?php echo Section::yield('scripts'); ?>
+		<?php echo Section::_yield('scripts'); ?>
 	</head>
 
 #### Using Blade short-cuts to work with sections:

--- a/app/laravel/helpers.php
+++ b/app/laravel/helpers.php
@@ -560,9 +560,9 @@ function render_each($partial, array $data, $iterator, $empty = 'raw|')
  * @param  string  $section
  * @return string
  */
-function yield($section)
+function _yield($section)
 {
-	return Laravel\Section::yield($section);
+	return Laravel\Section::_yield($section);
 }
 
 /**

--- a/app/laravel/section.php
+++ b/app/laravel/section.php
@@ -69,7 +69,7 @@ class Section {
 	 */
 	public static function yield_section()
 	{
-		return static::yield(static::stop());
+		return static::_yield(static::stop());
 	}
 
 	/**
@@ -128,7 +128,7 @@ class Section {
 	 * @param  string  $section
 	 * @return string
 	 */
-	public static function yield($section)
+	public static function _yield($section)
 	{
 		return (isset(static::$sections[$section])) ? static::$sections[$section] : '';
 	}

--- a/app/laravel/tests/cases/blade.test.php
+++ b/app/laravel/tests/cases/blade.test.php
@@ -74,7 +74,7 @@ class BladeTest extends PHPUnit_Framework_TestCase {
 	{
 		$blade = "@yield('something')";
 
-		$this->assertEquals("<?php echo \\Laravel\\Section::yield('something'); ?>", Blade::compile_string($blade));
+		$this->assertEquals("<?php echo \\Laravel\\Section::_yield('something'); ?>", Blade::compile_string($blade));
 	}
 
 	/**


### PR DESCRIPTION
This is required to support PHP 5.5, since yield is a keyword.
See https://github.com/laravel/laravel/commit/3298407238fd3e212cdf8d829adc6f519b941052
